### PR TITLE
Fix start activity method when arguments is empty or null

### DIFF
--- a/android/src/main/kotlin/io/navalia/braintree_checkout_flutter/VenmoActivity.kt
+++ b/android/src/main/kotlin/io/navalia/braintree_checkout_flutter/VenmoActivity.kt
@@ -7,7 +7,6 @@ import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
-
 import com.braintreepayments.api.venmo.VenmoClient
 import com.braintreepayments.api.venmo.VenmoLauncher
 import com.braintreepayments.api.venmo.VenmoPaymentAuthRequest

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: braintree_checkout_flutter
 description:  A Flutter plugin for integrating Braintree payments on iOS and Android. Supports PayPal and Venmo. 
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/NavaliaHQ/braintree_checkout_flutter
 
 environment:


### PR DESCRIPTION
✅ What does this PR do?
 Fixes the startActivity method to properly handle cases when its arguments are empty or null, preventing potential crashes or unintended behavior.

⚠️ What could go wrong?
- If the new check is too restrictive, it might block valid startActivity calls that should be allowed;
- If the empty/null handling logic is incorrect, it could cause unexpected navigation issues or prevent certain flows from starting.
