### PR TITLE
Nav 3/fix activity oncreate

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
         <activity
             android:name=".VenmoActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:theme="@android:style/Theme.Light.NoTitleBar"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize">

--- a/android/src/main/kotlin/io/navalia/braintree_checkout_flutter/PayPalActivity.kt
+++ b/android/src/main/kotlin/io/navalia/braintree_checkout_flutter/PayPalActivity.kt
@@ -21,16 +21,16 @@ class PayPalActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val intent = intent
-        
-        val token: String = intent.getStringExtra(Constants.TOKEN_KEY) as String
-        val displayName: String = intent.getStringExtra(Constants.DISPLAY_NAME_KEY) as String
-        val appLinkReturnUrl: String =
-            intent.getStringExtra(Constants.ANDROID_APP_LINK_RETURN_URL) as String
-        val deepLinkFallbackUrlScheme: String? =
-            intent.getStringExtra(Constants.ANDROID_DEEP_LINK_FALLBACK_URL_SCHEME)
-        val billingAgreementDescription: String? =
-            intent.getStringExtra(Constants.BILLING_AGREEMENT_DESCRIPTION)
+        val token = intent.getStringExtra(Constants.TOKEN_KEY)
+        val displayName = intent.getStringExtra(Constants.DISPLAY_NAME_KEY)
+        val appLinkReturnUrl = intent.getStringExtra(Constants.ANDROID_APP_LINK_RETURN_URL)
+        val deepLinkFallbackUrlScheme = intent.getStringExtra(Constants.ANDROID_DEEP_LINK_FALLBACK_URL_SCHEME)
+        val billingAgreementDescription = intent.getStringExtra(Constants.BILLING_AGREEMENT_DESCRIPTION)
+
+        if (token.isNullOrBlank() || displayName.isNullOrBlank() || appLinkReturnUrl.isNullOrBlank()) {
+            handleErrorResult(IllegalArgumentException("Missing required PayPal parameters"))
+            return
+        }
 
         paypalLauncher = PayPalLauncher()
         paypalClient = PayPalClient(

--- a/android/src/main/kotlin/io/navalia/braintree_checkout_flutter/VenmoActivity.kt
+++ b/android/src/main/kotlin/io/navalia/braintree_checkout_flutter/VenmoActivity.kt
@@ -25,14 +25,16 @@ class VenmoActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val intent = intent;
-        val token: String = intent.getStringExtra(Constants.TOKEN_KEY) as String
-        val displayName: String = intent.getStringExtra(Constants.DISPLAY_NAME_KEY) as String
-        val amount: String = intent.getStringExtra(Constants.AMOUNT_KEY) as String
-        val appLinkReturnUrl: String =
-            intent.getStringExtra(Constants.ANDROID_APP_LINK_RETURN_URL) as String
-        val deepLinkFallbackUrlScheme: String? =
-            intent.getStringExtra(Constants.ANDROID_DEEP_LINK_FALLBACK_URL_SCHEME)
+        val token = intent.getStringExtra(Constants.TOKEN_KEY)
+        val displayName = intent.getStringExtra(Constants.DISPLAY_NAME_KEY)
+        val amount = intent.getStringExtra(Constants.AMOUNT_KEY)
+        val appLinkReturnUrl = intent.getStringExtra(Constants.ANDROID_APP_LINK_RETURN_URL)
+        val deepLinkFallbackUrlScheme = intent.getStringExtra(Constants.ANDROID_DEEP_LINK_FALLBACK_URL_SCHEME)
+
+        if (token.isNullOrBlank() || displayName.isNullOrBlank() || amount.isNullOrBlank() || appLinkReturnUrl.isNullOrBlank()) {
+            handleErrorResult(IllegalArgumentException("Missing required Venmo parameters"))
+            return
+        }
 
         venmoLauncher = VenmoLauncher()
         venmoClient = VenmoClient(
@@ -46,7 +48,8 @@ class VenmoActivity : ComponentActivity() {
             VenmoPaymentMethodUsage.MULTI_USE,
             totalAmount = amount,
             displayName = displayName,
-            )
+        )
+
         startVenmoFlow(venmoRequest)
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: braintree_checkout_flutter
 description:  A Flutter plugin for integrating Braintree payments on iOS and Android. Supports PayPal and Venmo. 
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/NavaliaHQ/braintree_checkout_flutter
 
 environment:


### PR DESCRIPTION
✅ What does this PR do?

- Fixes onCreate behavior for PayPal activity;
- Fixes onCreate behavior for Venmo activity;
- Changes launch mode to singleTask to avoid multiple instances of the same activity;
- Updates the application version to 1.0.2.

These changes ensure payment activities initialize correctly and prevent duplicate activity launches.

⚠️ What could go wrong?

- Changing launch mode to singleTask could cause unexpected behavior in navigation or activity stack handling.