### PR TITLE
Revert onResume behavior to call handleReturnToApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+Adjust onResume for PayPal and Venmo activities
+
 ## 1.0.2
 
 Adjust launch mode to singleTask and add more guards

--- a/android/src/main/kotlin/io/navalia/braintree_checkout_flutter/PayPalActivity.kt
+++ b/android/src/main/kotlin/io/navalia/braintree_checkout_flutter/PayPalActivity.kt
@@ -22,34 +22,32 @@ class PayPalActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-         if (savedInstanceState == null) {
-            val token = intent.getStringExtra(Constants.TOKEN_KEY)
-            val displayName = intent.getStringExtra(Constants.DISPLAY_NAME_KEY)
-            val appLinkReturnUrl = intent.getStringExtra(Constants.ANDROID_APP_LINK_RETURN_URL)
-            val deepLinkFallbackUrlScheme = intent.getStringExtra(Constants.ANDROID_DEEP_LINK_FALLBACK_URL_SCHEME)
-            val billingAgreementDescription = intent.getStringExtra(Constants.BILLING_AGREEMENT_DESCRIPTION)
+        val token = intent.getStringExtra(Constants.TOKEN_KEY)
+        val displayName = intent.getStringExtra(Constants.DISPLAY_NAME_KEY)
+        val appLinkReturnUrl = intent.getStringExtra(Constants.ANDROID_APP_LINK_RETURN_URL)
+        val deepLinkFallbackUrlScheme = intent.getStringExtra(Constants.ANDROID_DEEP_LINK_FALLBACK_URL_SCHEME)
+        val billingAgreementDescription = intent.getStringExtra(Constants.BILLING_AGREEMENT_DESCRIPTION)
 
-            if (token.isNullOrBlank() || displayName.isNullOrBlank() || appLinkReturnUrl.isNullOrBlank()) {
-                handleErrorResult(IllegalArgumentException("Missing required PayPal parameters"))
-                return
-            }
-
-            paypalLauncher = PayPalLauncher()
-            paypalClient = PayPalClient(
-                context = this,
-                authorization = token,
-                appLinkReturnUrl = Uri.parse("$appLinkReturnUrl.paypal"),
-                deepLinkFallbackUrlScheme = "$deepLinkFallbackUrlScheme.paypal",
-            )
-
-            val payPalRequest = PayPalVaultRequest(
-                displayName = displayName,
-                hasUserLocationConsent = true,
-                billingAgreementDescription = billingAgreementDescription,
-            )
-
-            startPayPalFlow(payPalRequest)
+        if (token.isNullOrBlank() || displayName.isNullOrBlank() || appLinkReturnUrl.isNullOrBlank()) {
+            handleErrorResult(IllegalArgumentException("Missing required PayPal parameters"))
+            return
         }
+
+        paypalLauncher = PayPalLauncher()
+        paypalClient = PayPalClient(
+            context = this,
+            authorization = token,
+            appLinkReturnUrl = Uri.parse("$appLinkReturnUrl.paypal"),
+            deepLinkFallbackUrlScheme = "$deepLinkFallbackUrlScheme.paypal",
+        )
+
+        val payPalRequest = PayPalVaultRequest(
+            displayName = displayName,
+            hasUserLocationConsent = true,
+            billingAgreementDescription = billingAgreementDescription,
+        )
+
+        startPayPalFlow(payPalRequest)
     }
 
     private fun startPayPalFlow(request: PayPalVaultRequest) {
@@ -95,6 +93,11 @@ class PayPalActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        handleReturnToApp(intent)
+    }
+
+    override fun onResume() {
+        super.onResume()
         handleReturnToApp(intent)
     }
 

--- a/android/src/main/kotlin/io/navalia/braintree_checkout_flutter/VenmoActivity.kt
+++ b/android/src/main/kotlin/io/navalia/braintree_checkout_flutter/VenmoActivity.kt
@@ -26,34 +26,32 @@ class VenmoActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (savedInstanceState == null) {
-            val token = intent.getStringExtra(Constants.TOKEN_KEY)
-            val displayName = intent.getStringExtra(Constants.DISPLAY_NAME_KEY)
-            val amount = intent.getStringExtra(Constants.AMOUNT_KEY)
-            val appLinkReturnUrl = intent.getStringExtra(Constants.ANDROID_APP_LINK_RETURN_URL)
-            val deepLinkFallbackUrlScheme = intent.getStringExtra(Constants.ANDROID_DEEP_LINK_FALLBACK_URL_SCHEME)
+        val token = intent.getStringExtra(Constants.TOKEN_KEY)
+        val displayName = intent.getStringExtra(Constants.DISPLAY_NAME_KEY)
+        val amount = intent.getStringExtra(Constants.AMOUNT_KEY)
+        val appLinkReturnUrl = intent.getStringExtra(Constants.ANDROID_APP_LINK_RETURN_URL)
+        val deepLinkFallbackUrlScheme = intent.getStringExtra(Constants.ANDROID_DEEP_LINK_FALLBACK_URL_SCHEME)
 
-            if (token.isNullOrBlank() || displayName.isNullOrBlank() || amount.isNullOrBlank() || appLinkReturnUrl.isNullOrBlank()) {
-                handleErrorResult(IllegalArgumentException("Missing required Venmo parameters"))
-                return
-            }
-
-            venmoLauncher = VenmoLauncher()
-            venmoClient = VenmoClient(
-                context = this,
-                authorization = token,
-                appLinkReturnUrl = Uri.parse("$appLinkReturnUrl.venmo"),
-                deepLinkFallbackUrlScheme = "$deepLinkFallbackUrlScheme.venmo",
-            )
-
-            val venmoRequest = VenmoRequest(
-                VenmoPaymentMethodUsage.MULTI_USE,
-                totalAmount = amount,
-                displayName = displayName,
-            )
-
-            startVenmoFlow(venmoRequest)
+        if (token.isNullOrBlank() || displayName.isNullOrBlank() || amount.isNullOrBlank() || appLinkReturnUrl.isNullOrBlank()) {
+            handleErrorResult(IllegalArgumentException("Missing required Venmo parameters"))
+            return
         }
+
+        venmoLauncher = VenmoLauncher()
+        venmoClient = VenmoClient(
+            context = this,
+            authorization = token,
+            appLinkReturnUrl = Uri.parse("$appLinkReturnUrl.venmo"),
+            deepLinkFallbackUrlScheme = "$deepLinkFallbackUrlScheme.venmo",
+        )
+
+        val venmoRequest = VenmoRequest(
+            VenmoPaymentMethodUsage.MULTI_USE,
+            totalAmount = amount,
+            displayName = displayName,
+        )
+
+        startVenmoFlow(venmoRequest)
     }
 
     private fun startVenmoFlow(venmoRequest: VenmoRequest) {
@@ -101,6 +99,11 @@ class VenmoActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        handleReturnToApp(intent)
+    }
+
+    override fun onResume() {
+        super.onResume()
         handleReturnToApp(intent)
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: braintree_checkout_flutter
 description:  A Flutter plugin for integrating Braintree payments on iOS and Android. Supports PayPal and Venmo. 
-version: 1.0.2
+version: 1.0.3
 homepage: https://github.com/NavaliaHQ/braintree_checkout_flutter
 
 environment:


### PR DESCRIPTION
✅ **What does this PR do?**
- Reverts previous changes so that onResume in PayPal and Venmo activities once again calls handleReturnToApp;
- Increments the app version to 1.0.3.

This ensures that returning to the app from PayPal or Venmo triggers the appropriate handling logic, restoring expected payment flow behavior.

-----

⚠️ **What could go wrong?**

Any new payment logic that depended on the previous behavior may now break or behave unexpectedly.