### PR TITLE
Update PayPal launch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+Update launch mode on Android Manifest for PayPal
+
 ## 1.0.3
 
 Adjust onResume for PayPal and Venmo activities

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
         <activity
             android:name=".PayPalActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:theme="@android:style/Theme.Light.NoTitleBar"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustResize">

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: braintree_checkout_flutter
 description:  A Flutter plugin for integrating Braintree payments on iOS and Android. Supports PayPal and Venmo. 
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/NavaliaHQ/braintree_checkout_flutter
 
 environment:


### PR DESCRIPTION
✅ What does this PR do?

- Updates the Android Manifest to set PayPal activity launch mode to singleTask.

⚠️ What could go wrong?

- Changing the PayPal launch mode to singleTask could cause unexpected navigation or lifecycle issues if not handled properly.